### PR TITLE
feat(i18n): replace hardcoded text with translation keys in navbar an…

### DIFF
--- a/docs/fix-navbar-menu-translation-issue.md
+++ b/docs/fix-navbar-menu-translation-issue.md
@@ -1,0 +1,235 @@
+# Fix Navbar Menu Translation Issue - Hardcoded English Text Not Translating to Japanese
+
+## SEVERITY
+P1: High (Major functional error - core navigation feature not working as intended)
+
+## OBJECTIVE
+Replace hardcoded English menu items in the Navbar component with translation function calls to enable proper Japanese translation when language is switched.
+
+## CONTEXT
+- **File**: `src/components/layout/Navbar.tsx` [EXISTS]
+- **Current behavior**: Menu items "Home", "About", and "Contact" remain in English when user switches to Japanese language
+- **Root cause**: Menu item labels are hardcoded as English strings instead of using the translation function `t()` from LanguageContext
+
+## REPLICATION STEPS
+1. Open the application in a browser
+2. Navigate to any page with the Navbar visible
+3. Click the language switcher to change from English to Japanese
+4. Observe that the main navigation menu items ("Home", "About", "Contact") remain in English
+5. Observe that other UI elements (like "Call Us" button) translate correctly
+
+## PROBLEM
+
+### Location 1: src/components/layout/Navbar.tsx (Lines 101-119)
+```tsx
+<div className="nav-links-container flex items-center">
+  {['Home', 'About', 'Contact'].map((item, index) => (
+    <motion.div
+      key={item}
+      className="relative"
+      onHoverStart={() => handleHover(item)}
+      onHoverEnd={() => handleHover(null)}
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.1 * (index + 1) }}
+    >
+      <NavLink
+        to={item === 'Home' ? '/' : `/${item.toLowerCase()}`}
+        className={navLinkClass}
+      >
+        {item}
+```
+**Issue**: The array `['Home', 'About', 'Contact']` contains hardcoded English strings that are directly rendered without translation. The `{item}` on line 115 displays the untranslated English text.
+
+### Location 2: src/components/layout/Navbar.tsx (Lines 145-165)
+```tsx
+{['Home', 'About', 'Contact'].map((item, index) => (
+  <motion.div
+    key={item}
+    initial={{ opacity: 0, x: -20 }}
+    animate={{ opacity: 1, x: 0 }}
+    transition={{ delay: 0.1 * index }}
+  >
+    <NavLink
+      to={item === 'Home' ? '/' : `/${item.toLowerCase()}`}
+      className={({ isActive }) => `flex items-center space-x-2 px-3 py-2.5 rounded-xl ${isActive ? 'bg-[#3E5AC1]/10 text-[#F76C09]' : 'text-[#3E5AC1]'}`}
+      onClick={closeMenu}
+    >
+      {item === 'Home' && <Car size={18} />}
+      {item === 'About' && <Globe size={18} />}
+      {item === 'Contact' && <Phone size={18} />}
+      <span>{item}</span>
+    </NavLink>
+  </motion.div>
+))}
+```
+**Issue**: Same hardcoded array used in mobile menu. The `<span>{item}</span>` on line 161 displays untranslated English text in the mobile navigation.
+
+### Location 3: src/components/layout/Footer.tsx (Line 20)
+```tsx
+<span className="text-xs text-gray-300 uppercase tracking-tight">
+HEAVY MACHINERY TRADING REIMAGINED
+</span>
+```
+**Issue**: The tagline "HEAVY MACHINERY TRADING REIMAGINED" is hardcoded in English and does not translate to Japanese.
+
+### Location 4: src/contexts/LanguageContext.tsx (Lines 14-19)
+```typescript
+// Navigation
+'nav.home': 'Home',
+'nav.about': 'About',
+'nav.vehicles': 'Vehicles',
+'nav.contact': 'Contact',
+'nav.language': 'Language',
+```
+**Issue**: Translation keys exist in LanguageContext but are not being used in the Navbar component.
+
+## SUGGESTED HYPOTHESIS
+
+### Hypothesis 1: Map Translation Keys to Menu Items
+**Theory**: Create a mapping between menu item identifiers and their translation keys, then use the translation function to retrieve the localized text for each menu item.
+
+**File**: `src/components/layout/Navbar.tsx`
+
+```tsx
+// Define menu items with translation keys
+const menuItems = [
+  { key: 'home', translationKey: 'nav.home', path: '/', icon: Car },
+  { key: 'about', translationKey: 'nav.about', path: '/about', icon: Globe },
+  { key: 'contact', translationKey: 'nav.contact', path: '/contact', icon: Phone }
+];
+
+// Desktop Navigation (around line 101)
+<div className="nav-links-container flex items-center">
+  {menuItems.map((item, index) => (
+    <motion.div
+      key={item.key}
+      className="relative"
+      onHoverStart={() => handleHover(item.key)}
+      onHoverEnd={() => handleHover(null)}
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: 0.1 * (index + 1) }}
+    >
+      <NavLink
+        to={item.path}
+        className={navLinkClass}
+      >
+        {t(item.translationKey)}
+        {hoveredItem === item.key && (
+          <motion.div
+            className="absolute bottom-0 left-0 h-0.5 w-full bg-[#F76C09] rounded-full"
+            layoutId="underline"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          />
+        )}
+      </NavLink>
+    </motion.div>
+  ))}
+</div>
+
+// Mobile Navigation (around line 145)
+{menuItems.map((item, index) => {
+  const IconComponent = item.icon;
+  return (
+    <motion.div
+      key={item.key}
+      initial={{ opacity: 0, x: -20 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay: 0.1 * index }}
+    >
+      <NavLink
+        to={item.path}
+        className={({ isActive }) => `flex items-center space-x-2 px-3 py-2.5 rounded-xl ${isActive ? 'bg-[#3E5AC1]/10 text-[#F76C09]' : 'text-[#3E5AC1]'}`}
+        onClick={closeMenu}
+      >
+        <IconComponent size={18} />
+        <span>{t(item.translationKey)}</span>
+      </NavLink>
+    </motion.div>
+  );
+})}
+```
+
+**Trade-offs:**
+✅ Clean, maintainable code with single source of truth for menu items
+✅ Easy to add new menu items in the future
+✅ Consistent translation across desktop and mobile views
+⚠️ Requires updating hover state logic to use item.key instead of item string
+
+### Hypothesis 2: Direct Translation Function Calls
+**Theory**: Replace hardcoded strings with direct translation function calls inline, maintaining the existing array structure but translating each item.
+
+**File**: `src/components/layout/Navbar.tsx`
+
+```tsx
+// Desktop Navigation
+{[
+  { label: t('nav.home'), path: '/', key: 'home' },
+  { label: t('nav.about'), path: '/about', key: 'about' },
+  { label: t('nav.contact'), path: '/contact', key: 'contact' }
+].map((item, index) => (
+  <motion.div key={item.key}>
+    <NavLink to={item.path}>
+      {item.label}
+    </NavLink>
+  </motion.div>
+))}
+```
+
+**Trade-offs:**
+✅ Minimal code changes required
+✅ Straightforward implementation
+⚠️ Less maintainable - menu structure defined inline
+⚠️ Duplication between desktop and mobile menus
+
+## MUST PRESERVE
+- `useLanguage` hook from `../../contexts/LanguageContext` (line 5)
+- `t` function destructured from `useLanguage()` (line 13)
+- Existing translation keys in LanguageContext: `'nav.home'`, `'nav.about'`, `'nav.contact'` (lines 14-18 in LanguageContext.tsx)
+- NavLink routing logic: Home maps to `/`, others map to `/${item.toLowerCase()}`
+- Motion animations and hover effects
+- Mobile menu close functionality via `closeMenu()`
+- Icon components: `Car`, `Globe`, `Phone` from lucide-react
+
+## SUCCESS CRITERIA
+- When language is switched to Japanese, menu items display as: "ホーム", "会社概要", "お問い合わせ"
+- When language is switched to English, menu items display as: "Home", "About", "Contact"
+- Footer tagline translates between "HEAVY MACHINERY TRADING REIMAGINED" (English) and "重機取引の革新" (Japanese)
+- No breaking changes to navigation functionality
+- Hover effects and animations continue to work correctly
+- Mobile menu displays translated text
+- All existing routing paths remain functional
+
+## VERIFICATION STEPS
+1. **Test Desktop Navigation**: 
+   - Open application in browser
+   - Verify menu shows "Home", "About", "Contact" in English
+   - Click language switcher to Japanese
+   - Verify menu shows "ホーム", "会社概要", "お問い合わせ"
+   - Switch back to English and verify original labels return
+
+2. **Test Mobile Navigation**:
+   - Resize browser to mobile viewport (< 768px)
+   - Open mobile menu
+   - Verify menu items translate correctly when switching languages
+   - Verify icons remain visible next to translated text
+
+3. **Test Footer Tagline**:
+   - Scroll to footer
+   - Verify tagline translates when switching languages
+   - Check both desktop and mobile views
+
+4. **Check Dependents**:
+   - Verify no console errors in browser developer tools
+   - Test all navigation links still route correctly
+   - Verify hover effects still work on desktop menu items
+
+## CONSTRAINTS
+- Must not introduce TypeScript compilation errors
+- Must maintain existing component structure and props
+- Must not break existing animations or transitions
+- Must maintain accessibility features (aria-labels, sr-only text)
+- Must preserve responsive design behavior

--- a/package-lock.json
+++ b/package-lock.json
@@ -1514,17 +1514,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.1.tgz",
-      "integrity": "sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
+      "integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.46.1",
-        "@typescript-eslint/type-utils": "8.46.1",
-        "@typescript-eslint/utils": "8.46.1",
-        "@typescript-eslint/visitor-keys": "8.46.1",
+        "@typescript-eslint/scope-manager": "8.46.2",
+        "@typescript-eslint/type-utils": "8.46.2",
+        "@typescript-eslint/utils": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1538,7 +1538,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.46.1",
+        "@typescript-eslint/parser": "^8.46.2",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -1554,17 +1554,17 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.1.tgz",
-      "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
+      "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.46.1",
-        "@typescript-eslint/types": "8.46.1",
-        "@typescript-eslint/typescript-estree": "8.46.1",
-        "@typescript-eslint/visitor-keys": "8.46.1",
+        "@typescript-eslint/scope-manager": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/typescript-estree": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1580,14 +1580,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.1.tgz",
-      "integrity": "sha512-FOIaFVMHzRskXr5J4Jp8lFVV0gz5ngv3RHmn+E4HYxSJ3DgDzU7fVI1/M7Ijh1zf6S7HIoaIOtln1H5y8V+9Zg==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
+      "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.46.1",
-        "@typescript-eslint/types": "^8.46.1",
+        "@typescript-eslint/tsconfig-utils": "^8.46.2",
+        "@typescript-eslint/types": "^8.46.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1602,14 +1602,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.1.tgz",
-      "integrity": "sha512-weL9Gg3/5F0pVQKiF8eOXFZp8emqWzZsOJuWRUNtHT+UNV2xSJegmpCNQHy37aEQIbToTq7RHKhWvOsmbM680A==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
+      "integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.1",
-        "@typescript-eslint/visitor-keys": "8.46.1"
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1620,9 +1620,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.1.tgz",
-      "integrity": "sha512-X88+J/CwFvlJB+mK09VFqx5FE4H5cXD+H/Bdza2aEWkSb8hnWIQorNcscRl4IEo1Cz9VI/+/r/jnGWkbWPx54g==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
+      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1637,15 +1637,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.1.tgz",
-      "integrity": "sha512-+BlmiHIiqufBxkVnOtFwjah/vrkF4MtKKvpXrKSPLCkCtAp8H01/VV43sfqA98Od7nJpDcFnkwgyfQbOG0AMvw==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
+      "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.1",
-        "@typescript-eslint/typescript-estree": "8.46.1",
-        "@typescript-eslint/utils": "8.46.1",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/typescript-estree": "8.46.2",
+        "@typescript-eslint/utils": "8.46.2",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1662,9 +1662,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.1.tgz",
-      "integrity": "sha512-C+soprGBHwWBdkDpbaRC4paGBrkIXxVlNohadL5o0kfhsXqOC6GYH2S/Obmig+I0HTDl8wMaRySwrfrXVP8/pQ==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
+      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1676,16 +1676,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.1.tgz",
-      "integrity": "sha512-uIifjT4s8cQKFQ8ZBXXyoUODtRoAd7F7+G8MKmtzj17+1UbdzFl52AzRyZRyKqPHhgzvXunnSckVu36flGy8cg==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
+      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.46.1",
-        "@typescript-eslint/tsconfig-utils": "8.46.1",
-        "@typescript-eslint/types": "8.46.1",
-        "@typescript-eslint/visitor-keys": "8.46.1",
+        "@typescript-eslint/project-service": "8.46.2",
+        "@typescript-eslint/tsconfig-utils": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/visitor-keys": "8.46.2",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1744,16 +1744,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.1.tgz",
-      "integrity": "sha512-vkYUy6LdZS7q1v/Gxb2Zs7zziuXN0wxqsetJdeZdRe/f5dwJFglmuvZBfTUivCtjH725C1jWCDfpadadD95EDQ==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
+      "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.1",
-        "@typescript-eslint/types": "8.46.1",
-        "@typescript-eslint/typescript-estree": "8.46.1"
+        "@typescript-eslint/scope-manager": "8.46.2",
+        "@typescript-eslint/types": "8.46.2",
+        "@typescript-eslint/typescript-estree": "8.46.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1768,13 +1768,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.1.tgz",
-      "integrity": "sha512-ptkmIf2iDkNUjdeu2bQqhFPV1m6qTnFFjg7PPDjxKWaMaP0Z6I9l30Jr3g5QqbZGdw8YdYvLp+XnqnWWZOg/NA==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
+      "integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.1",
+        "@typescript-eslint/types": "8.46.2",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -3901,13 +3901,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -4429,16 +4429,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.46.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.1.tgz",
-      "integrity": "sha512-VHgijW803JafdSsDO8I761r3SHrgk4T00IdyQ+/UsthtgPRsBWQLqoSxOolxTpxRKi1kGXK0bSz4CoAc9ObqJA==",
+      "version": "8.46.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.46.2.tgz",
+      "integrity": "sha512-vbw8bOmiuYNdzzV3lsiWv6sRwjyuKJMQqWulBOU7M0RrxedXledX8G8kBbQeiOYDnTfiXz0Y4081E1QMNB6iQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.46.1",
-        "@typescript-eslint/parser": "8.46.1",
-        "@typescript-eslint/typescript-estree": "8.46.1",
-        "@typescript-eslint/utils": "8.46.1"
+        "@typescript-eslint/eslint-plugin": "8.46.2",
+        "@typescript-eslint/parser": "8.46.2",
+        "@typescript-eslint/typescript-estree": "8.46.2",
+        "@typescript-eslint/utils": "8.46.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4501,9 +4501,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.10.tgz",
-      "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -17,7 +17,7 @@ const Footer = () => {
                   BIG TRADING
                 </span>
                 <span className="text-xs text-gray-300 uppercase tracking-tight">
-                HEAVY MACHINERY TRADING REIMAGINED
+                {t('business.navbarTagline')}
                 </span>
               </div>
             </Link>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -110,7 +110,7 @@ const Navbar = () => {
                     to={item === 'Home' ? '/' : `/${item.toLowerCase()}`}
                     className={navLinkClass}
                   >
-                    {item}
+                    {t(`nav.${item.toLowerCase()}`)}
                     {hoveredItem === item && (
                       <motion.div
                         className="absolute bottom-0 left-0 h-0.5 w-full bg-[#F76C09] rounded-full"
@@ -135,7 +135,7 @@ const Navbar = () => {
               transition={{ delay: 0.5 }}
             >
               <Phone size={16} />
-              <span className="text-sm font-medium">Call Us</span>
+              <span className="text-sm font-medium">{t('cta.callUs')}</span>
             </motion.a>
             <div className="ml-4">
               <LanguageSwitcher className="bg-gray-100 hover:bg-gray-200 text-[#3E5AC1]" />
@@ -207,7 +207,7 @@ const Navbar = () => {
                     {item === 'Home' && <Car size={18} />}
                     {item === 'About' && <Globe size={18} />}
                     {item === 'Contact' && <Phone size={18} />}
-                    <span>{item}</span>
+                    <span>{t(`nav.${item.toLowerCase()}`)}</span>
                   </NavLink>
                 </motion.div>
               ))}


### PR DESCRIPTION
…d footer

Add translation support for navbar menu items and footer tagline by replacing hardcoded English text with calls to the translation function. This enables proper localization when switching between English and Japanese languages.

The changes include:
- Using t('nav.home'), t('nav.about'), t('nav.contact') for menu items
- Using t('business.navbarTagline') for footer tagline
- Maintaining all existing functionality and animations